### PR TITLE
Centered Sponsor logos, centered atlas credit. Added new embed meta tags.

### DIFF
--- a/src/_data/site.yml
+++ b/src/_data/site.yml
@@ -102,4 +102,4 @@ home:
       link: https://rewritingthecode.org/
 
 footer:
-  credit: Created from Redbrick's Atlas System
+  credit: Powered by Redbrick's Atlas System

--- a/src/_includes/global/footer.njk
+++ b/src/_includes/global/footer.njk
@@ -6,8 +6,8 @@
       <br />{{ site.society.tagline }}
     </p>
   </aside>
-  <div class="items-center grid-flow-col md:place-self-center md:justify-self-center">
-    <a href="https://github.com/redbrick/atlas" rel="noreferrer" target="_blank" class="transition hover:opacity-75">
+  <div class="absolute items-center grid-flow-col md:place-self-center md:justify-self-center">
+    <a href="https://github.com/redbrick/atlas" rel="noreferrer" target="_blank" class="absolute transition hover:opacity-75">
       {{site.footer.credit}}
     </a>
   </div>

--- a/src/_includes/global/footer.njk
+++ b/src/_includes/global/footer.njk
@@ -7,7 +7,7 @@
     </p>
   </aside>
   <div class="absolute items-center grid-flow-col md:place-self-center md:justify-self-center">
-    <a href="https://github.com/redbrick/atlas" rel="noreferrer" target="_blank" class="absolute transition hover:opacity-75">
+    <a href="https://github.com/redbrick/atlas" rel="noreferrer" target="_blank" class="transition hover:opacity-75">
       {{site.footer.credit}}
     </a>
   </div>

--- a/src/_includes/home/sections/sponsors.njk
+++ b/src/_includes/home/sections/sponsors.njk
@@ -7,7 +7,7 @@
     <div data-sponsor-trigger class="flex flex-col items-center">
       <div data-sponsor-card class="indicator overflow-visible">
         <div class="relative overflow-hidden">
-          <a href="{{ sponsor.link }}">
+          <a href="{{ sponsor.link }}" class="flex items-center">
             <img class="-z-10 w-40 object-cover object-center" src="{{ sponsor.image }}" alt="{{ sponsor.name }}" />
             <div class="bottom-0 w-full p-2 sponsor-name">
                 <p class="text-center md:text-lg flex hover:text-primary transition-all">

--- a/src/_includes/home/sections/sponsors.njk
+++ b/src/_includes/home/sections/sponsors.njk
@@ -7,7 +7,7 @@
     <div data-sponsor-trigger class="flex flex-col items-center">
       <div data-sponsor-card class="indicator overflow-visible">
         <div class="relative overflow-hidden">
-          <a href="{{ sponsor.link }}" class="flex items-center">
+          <a href="{{ sponsor.link }}" class="flex flex-col items-center">
             <img class="-z-10 w-40 object-cover object-center" src="{{ sponsor.image }}" alt="{{ sponsor.name }}" />
             <div class="bottom-0 w-full p-2 sponsor-name">
                 <p class="text-center md:text-lg flex hover:text-primary transition-all">

--- a/src/_layouts/base.njk
+++ b/src/_layouts/base.njk
@@ -11,11 +11,14 @@ title: CS++
     <link rel="stylesheet" href="/assets/main.css" />
     <title>{{ title }}</title>
 
-    <meta property="og:type" content="website" />
+    <meta property="og:type" content="website" >
     <meta property="og:url" content="https://cspp.ie/" />
-    <meta property="og:title" content="{{site.society.name}}" />
-    <meta property="og:description" content="{{site.society.tagline}}" />
+    <meta property="og:title" content="{{site.society.name}}" >
+    <meta property="og:description" content="{{site.society.tagline}}" >
     <meta property="og:image" content="{{site.images.roundel}}" />
+    <meta property="og:image:type" content="image/png" >
+    <meta property="og:image:width" content="120" >
+    <meta property="og:image:height" content="63" >
 
     <script defer data-domain="cspp.ie" src="https://plausible.io/js/script.js"></script>
 


### PR DESCRIPTION
This PR closes #20, closes #6 and closes #19.

The logos of our sponsors are now correctly centered above their name.
The Credit to Atlas is now centered to the view, as opposed to being centered between the two other elements within the footer.
The CS++ logo should now appear in the embed.