### PR TITLE
Fixed Footer & Sponsor bugs

### DIFF
--- a/src/_includes/global/footer.njk
+++ b/src/_includes/global/footer.njk
@@ -6,7 +6,7 @@
       <br />{{ site.society.tagline }}
     </p>
   </aside>
-  <div class="absolute items-center grid-flow-col md:place-self-center md:justify-self-center">
+  <div class="md:absolute items-center grid-flow-col md:place-self-center md:justify-self-center">
     <a href="https://github.com/redbrick/atlas" rel="noreferrer" target="_blank" class="transition hover:opacity-75">
       {{site.footer.credit}}
     </a>

--- a/src/_includes/home/sections/sponsors.njk
+++ b/src/_includes/home/sections/sponsors.njk
@@ -8,7 +8,7 @@
       <div data-sponsor-card class="indicator overflow-visible">
         <div class="relative overflow-hidden">
           <a href="{{ sponsor.link }}" class="flex flex-col items-center">
-            <img class="-z-10 w-40 object-cover object-center" src="{{ sponsor.image }}" alt="{{ sponsor.name }} Logo" />
+            <img class="w-40 object-cover object-center" src="{{ sponsor.image }}" alt="{{ sponsor.name }} Logo" />
             <div class="bottom-0 w-full p-2 sponsor-name">
                 <p class="text-center md:text-lg flex hover:text-primary transition-all">
                 {{ sponsor.name }}


### PR DESCRIPTION
This commit closes #30 where sponsor logos disappear on mobile.
This was done due to a z-index error (Thank you mae!)

This commit also closes #26 where the RB thanks text crashes into the other text in the footer on mobiles.
This happened due to the absolute positioning, which is now screen-size dependent.