### PR TITLE
[📈] Added Plausible

### DIFF
--- a/src/_layouts/base.njk
+++ b/src/_layouts/base.njk
@@ -20,7 +20,8 @@ title: CS++
     <meta property="og:image:width" content="120" >
     <meta property="og:image:height" content="63" >
 
-    <script defer data-domain="cspp.ie" src="https://plausible.io/js/script.js"></script>
+    <script defer data-domain="cspp.ie" src="https://plausible.cspp.ie/js/script.file-downloads.outbound-links.js"></script>
+    <script>window.plausible = window.plausible || function() { (window.plausible.q = window.plausible.q || []).push(arguments) }</script>
 
     <script src="https://cdn.jsdelivr.net/npm/ua-parser-js@1.0.37/src/ua-parser.min.js"></script>
     <script>


### PR DESCRIPTION
This will allow Plausible to track pageviews in a GDPR compliant manner.

Plausible is fully GDPR-compliant and does not require a privacy policy.